### PR TITLE
Add persistent SQLite storage for activities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 *.log
 *.sql
 *.sqlite
+*.db
 
 # OS generated files #
 ######################

--- a/src/README.md
+++ b/src/README.md
@@ -6,22 +6,29 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Persist activities and enrollments in SQLite
 
 ## Getting Started
 
 1. Install the dependencies:
 
    ```
-   pip install fastapi uvicorn
+   pip install -r ../requirements.txt
    ```
 
-2. Run the application:
+2. Initialize (or reset) the database with starter data:
 
    ```
-   python app.py
+   python bootstrap_db.py
    ```
 
-3. Open your browser and go to:
+3. Run the application:
+
+   ```
+   uvicorn app:app --reload
+   ```
+
+4. Open your browser and go to:
    - API documentation: http://localhost:8000/docs
    - Alternative documentation: http://localhost:8000/redoc
 
@@ -47,4 +54,4 @@ The application uses a simple data model with meaningful identifiers:
    - Name
    - Grade level
 
-All data is stored in memory, which means data will be reset when the server restarts.
+Data is stored in `activities.db`, so activities and enrollments persist across server restarts.

--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,11 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
 import os
+import sqlite3
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -19,63 +20,143 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
+DB_PATH = current_dir / "activities.db"
+
+INITIAL_ACTIVITIES = [
+    {
+        "name": "Chess Club",
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
     },
-    "Programming Class": {
+    {
+        "name": "Programming Class",
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
     },
-    "Gym Class": {
+    {
+        "name": "Gym Class",
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
     },
-    "Soccer Team": {
+    {
+        "name": "Soccer Team",
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
     },
-    "Basketball Team": {
+    {
+        "name": "Basketball Team",
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
     },
-    "Art Club": {
+    {
+        "name": "Art Club",
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
     },
-    "Drama Club": {
+    {
+        "name": "Drama Club",
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
     },
-    "Math Club": {
+    {
+        "name": "Math Club",
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
     },
-    "Debate Team": {
+    {
+        "name": "Debate Team",
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
+]
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def initialize_database() -> None:
+    with get_connection() as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS activities (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL,
+                schedule TEXT NOT NULL,
+                max_participants INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS participants (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                activity_id INTEGER NOT NULL,
+                email TEXT NOT NULL,
+                UNIQUE(activity_id, email),
+                FOREIGN KEY(activity_id) REFERENCES activities(id) ON DELETE CASCADE
+            )
+            """
+        )
+
+        existing_count = conn.execute(
+            "SELECT COUNT(*) AS count FROM activities"
+        ).fetchone()["count"]
+
+        if existing_count == 0:
+            for activity in INITIAL_ACTIVITIES:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO activities (name, description, schedule, max_participants)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        activity["name"],
+                        activity["description"],
+                        activity["schedule"],
+                        activity["max_participants"],
+                    ),
+                )
+                activity_id = cursor.lastrowid
+
+                for email in activity["participants"]:
+                    conn.execute(
+                        "INSERT INTO participants (activity_id, email) VALUES (?, ?)",
+                        (activity_id, email),
+                    )
+
+
+def get_activity_by_name(conn: sqlite3.Connection, activity_name: str) -> sqlite3.Row | None:
+    return conn.execute(
+        "SELECT id, name, description, schedule, max_participants FROM activities WHERE name = ?",
+        (activity_name,),
+    ).fetchone()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    initialize_database()
 
 
 @app.get("/")
@@ -85,48 +166,76 @@ def root():
 
 @app.get("/activities")
 def get_activities():
-    return activities
+    with get_connection() as conn:
+        activity_rows = conn.execute(
+            "SELECT id, name, description, schedule, max_participants FROM activities ORDER BY id"
+        ).fetchall()
+
+        activities = {
+            row["name"]: {
+                "description": row["description"],
+                "schedule": row["schedule"],
+                "max_participants": row["max_participants"],
+                "participants": [],
+            }
+            for row in activity_rows
+        }
+
+        participant_rows = conn.execute(
+            """
+            SELECT a.name, p.email
+            FROM participants p
+            JOIN activities a ON a.id = p.activity_id
+            ORDER BY p.id
+            """
+        ).fetchall()
+
+        for row in participant_rows:
+            activities[row["name"]]["participants"].append(row["email"])
+
+        return activities
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
     """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        activity = get_activity_by_name(conn, activity_name)
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+        existing = conn.execute(
+            "SELECT 1 FROM participants WHERE activity_id = ? AND email = ?",
+            (activity["id"], email),
+        ).fetchone()
+        if existing is not None:
+            raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
+        conn.execute(
+            "INSERT INTO participants (activity_id, email) VALUES (?, ?)",
+            (activity["id"], email),
         )
 
-    # Add student
-    activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
     """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
-        raise HTTPException(status_code=404, detail="Activity not found")
+    with get_connection() as conn:
+        activity = get_activity_by_name(conn, activity_name)
+        if activity is None:
+            raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+        cursor = conn.execute(
+            "DELETE FROM participants WHERE activity_id = ? AND email = ?",
+            (activity["id"], email),
         )
 
-    # Remove student
-    activity["participants"].remove(email)
+        if cursor.rowcount == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Student is not signed up for this activity",
+            )
+
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/bootstrap_db.py
+++ b/src/bootstrap_db.py
@@ -1,0 +1,28 @@
+"""Utility script to initialize or reset the SQLite database."""
+
+from pathlib import Path
+import sqlite3
+
+from app import DB_PATH, INITIAL_ACTIVITIES, initialize_database
+
+
+def reset_database() -> None:
+    if Path(DB_PATH).exists():
+        Path(DB_PATH).unlink()
+
+    initialize_database()
+
+
+def print_summary() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        activities = conn.execute("SELECT COUNT(*) FROM activities").fetchone()[0]
+        participants = conn.execute("SELECT COUNT(*) FROM participants").fetchone()[0]
+
+    print(f"Database ready at: {DB_PATH}")
+    print(f"Seeded activities: {activities} (expected {len(INITIAL_ACTIVITIES)})")
+    print(f"Seeded participants: {participants}")
+
+
+if __name__ == "__main__":
+    reset_database()
+    print_summary()


### PR DESCRIPTION
## Summary
- replace in-memory activity storage with SQLite-backed persistence
- initialize and seed `activities.db` on startup if empty
- keep existing endpoints (`GET /activities`, signup, unregister) compatible
- add `src/bootstrap_db.py` helper to reset and seed database
- update setup docs for DB bootstrap and uvicorn run flow

## Validation
- static error check passed for updated Python files
- manual smoke test attempt was started; final run was skipped in-tool by user choice
